### PR TITLE
Fix | Development support for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ a star to let me know you are interested in this project.
 Installation
 ------------
 
+## Development
+
+This section will walk you through setting up the environment required to modify
+the source of `yewprint`.
+
 ### Prerequisites
 
- *  wasm-pack
- *  cargo-watch
- *  Rust nightly
+- [Rust](https://rustup.rs/)
+  - [wasm-pack](https://github.com/rustwasm/wasm-pack)
+  - [simple-http-server](https://github.com/TheWaWaR/simple-http-server)
+  - [cargo-watch](https://github.com/passcod/cargo-watch)
+
+> You may encounter issues when running this command on MacOS. Refer to this issue for more details [cargo-watch/issues/129](https://github.com/passcod/cargo-watch/issues/129)
 
 ### Use as a library
 
@@ -28,7 +36,6 @@ yewprint = { git = "https://github.com/cecton/yewprint.git", branch = "main" }
 ### Development server
 
 ```
-rustup override set nightly
 ./dev.sh
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -11,10 +11,20 @@ if ! [ -f core.tgz ]; then
 fi
 
 mkdir -p static
+
 rm -fR static/.gitignore static/*
-tar xvzf core.tgz -C static --wildcards \*.css --transform='s/.*\///'
+
+# decompress the tar file but extract the `.css` files only
+# find every file in the nested directories and move it behind `./static`
+# finally remove every directory behind `./static`
+bsdtar xvzf core.tgz -C static \*.css &&
+	find ./static -mindepth 2 -type f -print -exec mv {} ./static \; &&
+	find ./static -mindepth 1 -type d -print -exec rm -rf {} \;
+
 wasm-pack build --no-typescript --target web --out-name wasm --out-dir ./static "${options[@]}" "$@"
+
 rc=$?
+
 rm -fR static/{.gitignore,package.json}
 
 exit $rc

--- a/dev.sh
+++ b/dev.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-exec cargo watch -s './build.sh --dev -- --features dev && simple-http-server -i --nocache --cors' -w src
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	# if current OS is `darwin` then avoid running `cargo watch` by default
+	# refer to: https://github.com/passcod/cargo-watch/issues/129
+	./build.sh --dev -- --features dev && simple-http-server -i --nocache --cors
+else
+	exec cargo watch -s './build.sh --dev -- --features dev && simple-http-server -i --nocache --cors' -w src
+fi


### PR DESCRIPTION
This PR updates bash scripts to be compatible for both Linux and MacOS.

Replaces `tar` with explicit `bsdtar` and  makes us of arguments available in both environments.

Also provides links to the crates required for development.