### PR TITLE
Breaking API change in 1.0.58: could not find `export` in `syn`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "cfg-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,7 +116,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "wasm-bindgen",
 ]
 
@@ -120,7 +126,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -129,7 +135,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -140,101 +146,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "futures"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
-
-[[package]]
-name = "futures-task"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "futures-util"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project",
- "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
- "slab",
-]
 
 [[package]]
 name = "gloo"
@@ -373,7 +284,7 @@ checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
 ]
@@ -405,7 +316,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -455,12 +366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
-
-[[package]]
 name = "onig"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,32 +388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,22 +408,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -645,9 +512,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -731,7 +598,7 @@ version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -758,7 +625,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -851,16 +718,15 @@ dependencies = [
 
 [[package]]
 name = "yew"
-version = "0.17.3"
-source = "git+https://github.com/yewstack/yew.git?rev=1507c21b#1507c21b39e7941f7b9fe8ff5af792cf55be1f6f"
+version = "0.17.4"
+source = "git+https://github.com/yewstack/yew.git?rev=db3170f629f#db3170f629fc91b15c68b12d4204d6f1394520f4"
 dependencies = [
  "anyhow",
  "anymap",
  "bincode",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cfg-match",
  "console_error_panic_hook",
- "futures",
  "gloo",
  "http",
  "indexmap",
@@ -880,7 +746,7 @@ dependencies = [
 [[package]]
 name = "yew-macro"
 version = "0.17.0"
-source = "git+https://github.com/yewstack/yew.git?rev=1507c21b#1507c21b39e7941f7b9fe8ff5af792cf55be1f6f"
+source = "git+https://github.com/yewstack/yew.git?rev=db3170f629f#db3170f629fc91b15c68b12d4204d6f1394520f4"
 dependencies = [
  "boolinator",
  "lazy_static",
@@ -892,9 +758,9 @@ dependencies = [
 [[package]]
 name = "yew-router"
 version = "0.14.0"
-source = "git+https://github.com/yewstack/yew.git?rev=1507c21b#1507c21b39e7941f7b9fe8ff5af792cf55be1f6f"
+source = "git+https://github.com/yewstack/yew.git?rev=db3170f629f#db3170f629fc91b15c68b12d4204d6f1394520f4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cfg-match",
  "gloo",
  "js-sys",
@@ -912,7 +778,7 @@ dependencies = [
 [[package]]
 name = "yew-router-macro"
 version = "0.14.0"
-source = "git+https://github.com/yewstack/yew.git?rev=1507c21b#1507c21b39e7941f7b9fe8ff5af792cf55be1f6f"
+source = "git+https://github.com/yewstack/yew.git?rev=db3170f629f#db3170f629fc91b15c68b12d4204d6f1394520f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -923,7 +789,7 @@ dependencies = [
 [[package]]
 name = "yew-router-route-parser"
 version = "0.14.0"
-source = "git+https://github.com/yewstack/yew.git?rev=1507c21b#1507c21b39e7941f7b9fe8ff5af792cf55be1f6f"
+source = "git+https://github.com/yewstack/yew.git?rev=db3170f629f#db3170f629fc91b15c68b12d4204d6f1394520f4"
 dependencies = [
  "nom",
 ]
@@ -956,21 +822,21 @@ dependencies = [
 
 [[package]]
 name = "yewtil"
-version = "0.3.1"
-source = "git+https://github.com/yewstack/yew.git?rev=1507c21b#1507c21b39e7941f7b9fe8ff5af792cf55be1f6f"
+version = "0.3.2"
+source = "git+https://github.com/yewstack/yew.git?rev=db3170f629f#db3170f629fc91b15c68b12d4204d6f1394520f4"
 dependencies = [
- "futures",
  "log",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
  "yew",
  "yewtil-macro",
 ]
 
 [[package]]
 name = "yewtil-macro"
-version = "0.1.0"
-source = "git+https://github.com/yewstack/yew.git?rev=1507c21b#1507c21b39e7941f7b9fe8ff5af792cf55be1f6f"
+version = "0.2.0"
+source = "git+https://github.com/yewstack/yew.git?rev=db3170f629f#db3170f629fc91b15c68b12d4204d6f1394520f4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/yewprint-doc/Cargo.toml
+++ b/yewprint-doc/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "^0.2"
-yew = { git = "https://github.com/yewstack/yew.git", rev = "1507c21b" }
+yew = { git = "https://github.com/yewstack/yew.git", rev = "db3170f629f" }
 web-sys = { version = "0.3", features = ["Window", "MediaQueryList"] }
 yewprint = { path = "../yewprint" }
-yew-router = { git = "https://github.com/yewstack/yew.git", rev = "1507c21b" }
+yew-router = { git = "https://github.com/yewstack/yew.git", rev = "db3170f629f" }
 # NOTE: this dependency needs to be removed when the feature bool_to_option lands in stable
 #       https://github.com/rust-lang/rust/issues/64260
 boolinator = "2.4.0"

--- a/yewprint-doc/src/app.rs
+++ b/yewprint-doc/src/app.rs
@@ -84,19 +84,19 @@ impl Component for App {
 
         html! {
             <div class=classes!("docs-root", self.dark_theme.as_some("bp3-dark"))>
-                <div class="docs-app">
-                    <div class="docs-nav-wrapper">
-                        <div class="docs-nav">
-                            <div class="docs-nav-title">
-                                <a class="docs-logo" href="/">
+                <div class=classes!("docs-app")>
+                    <div class=classes!("docs-nav-wrapper")>
+                        <div class=classes!("docs-nav")>
+                            <div class=classes!("docs-nav-title")>
+                                <a class=classes!("docs-logo") href="/">
                                     {crate::include_raw_html!("logo.svg")}
                                 </a>
                                 <div>
-                                    <div class="bp3-navbar-heading docs-heading">
+                                    <div class=classes!("bp3-navbar-heading", "docs-heading")>
                                         {"Yewprint"}
                                     </div>
                                     <a
-                                        class="bp3-text-muted"
+                                        class=classes!("bp3-text-muted")
                                         href="https://github.com/cecton/yewprint"
                                         target="_blank"
                                     >
@@ -226,8 +226,8 @@ impl Component for App {
                             </div>
                         </div>
                     </div>
-                    <main class="docs-content-wrapper" role="main">
-                        <div class="docs-page">
+                    <main class=classes!("docs-content-wrapper") role="main">
+                        <div class=classes!("docs-page")>
                             <Router<DocMenu, ()>
                                 render=Router::render(|switch: DocMenu| {
                                     match switch {

--- a/yewprint-doc/src/button_group/mod.rs
+++ b/yewprint-doc/src/button_group/mod.rs
@@ -44,7 +44,7 @@ impl Component for ButtonGroupDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Button Group"}</H1>
+                <H1 class=classes!("docs-title")>{"Button Group"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html! {

--- a/yewprint-doc/src/buttons/mod.rs
+++ b/yewprint-doc/src/buttons/mod.rs
@@ -43,7 +43,7 @@ impl Component for ButtonDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Button"}</H1>
+                <H1 class=classes!("docs-title")>{"Button"}</H1>
                 <div>
                     <ExampleContainer
                         source=source

--- a/yewprint-doc/src/callout/mod.rs
+++ b/yewprint-doc/src/callout/mod.rs
@@ -43,7 +43,7 @@ impl Component for CalloutDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Callout"}</H1>
+                <H1 class=classes!("docs-title")>{"Callout"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html! {

--- a/yewprint-doc/src/card/mod.rs
+++ b/yewprint-doc/src/card/mod.rs
@@ -42,7 +42,7 @@ impl Component for CardDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Card"}</H1>
+                <H1 class=classes!("docs-title")>{"Card"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html! {

--- a/yewprint-doc/src/collapse/mod.rs
+++ b/yewprint-doc/src/collapse/mod.rs
@@ -31,7 +31,7 @@ impl Component for CollapseDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Collapse"}</H1>
+                <H1 class=classes!("docs-title")>{"Collapse"}</H1>
                 <ExampleContainer source=source>
                     <Example />
                 </ExampleContainer>

--- a/yewprint-doc/src/control_group/mod.rs
+++ b/yewprint-doc/src/control_group/mod.rs
@@ -42,7 +42,7 @@ impl Component for ControlGroupDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"ControlGroup"}</H1>
+                <H1 class=classes!("docs-title")>{"ControlGroup"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html! {

--- a/yewprint-doc/src/divider/mod.rs
+++ b/yewprint-doc/src/divider/mod.rs
@@ -39,7 +39,7 @@ impl Component for DividerDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Divider"}</H1>
+                <H1 class=classes!("docs-title")>{"Divider"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html! {

--- a/yewprint-doc/src/example.rs
+++ b/yewprint-doc/src/example.rs
@@ -49,15 +49,15 @@ impl Component for ExampleContainer {
 
     fn view(&self) -> Html {
         html! {
-            <div class="docs-example-wrapper">
-                <div class="docs-example-frame docs-example-frame-row">
-                    <div class="docs-example">
+            <div class=classes!("docs-example-wrapper")>
+                <div class=classes!("docs-example-frame", "docs-example-frame-row")>
+                    <div class=classes!("docs-example")>
                         {self.props.children.clone()}
                     </div>
                     {
                         if let Some(props) = self.props.props.clone() {
                             html! {
-                                <div class="docs-example-options">
+                                <div class=classes!("docs-example-options")>
                                     {props}
                                 </div>
                             }
@@ -66,7 +66,7 @@ impl Component for ExampleContainer {
                         }
                     }
                 </div>
-                <div class="docs-source">
+                <div class=classes!("docs-source")>
                     <Button
                         icon=IconName::Code
                         fill={true}

--- a/yewprint-doc/src/html_select/mod.rs
+++ b/yewprint-doc/src/html_select/mod.rs
@@ -44,7 +44,7 @@ impl Component for HtmlSelectDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"HtmlSelect"}</H1>
+                <H1 class=classes!("docs-title")>{"HtmlSelect"}</H1>
                 <div>
                     <ExampleContainer
                         source=source

--- a/yewprint-doc/src/icon/mod.rs
+++ b/yewprint-doc/src/icon/mod.rs
@@ -31,7 +31,7 @@ impl Component for IconDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Icon"}</H1>
+                <H1 class=classes!("docs-title")>{"Icon"}</H1>
                 <ExampleContainer source=source>
                     <Example />
                 </ExampleContainer>

--- a/yewprint-doc/src/input_group/mod.rs
+++ b/yewprint-doc/src/input_group/mod.rs
@@ -45,7 +45,7 @@ impl Component for InputGroupDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"InputGroup"}</H1>
+                <H1 class=classes!("docs-title")>{"InputGroup"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html! {

--- a/yewprint-doc/src/menu/mod.rs
+++ b/yewprint-doc/src/menu/mod.rs
@@ -31,7 +31,7 @@ impl Component for MenuDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Menu"}</H1>
+                <H1 class=classes!("docs-title")>{"Menu"}</H1>
                 <ExampleContainer source=source>
                     <Example />
                 </ExampleContainer>

--- a/yewprint-doc/src/progressbar/mod.rs
+++ b/yewprint-doc/src/progressbar/mod.rs
@@ -43,7 +43,7 @@ impl Component for ProgressBarDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"ProgressBar"}</H1>
+                <H1 class=classes!("docs-title")>{"ProgressBar"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html! {

--- a/yewprint-doc/src/switch/mod.rs
+++ b/yewprint-doc/src/switch/mod.rs
@@ -43,7 +43,7 @@ impl Component for SwitchDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Switch"}</H1>
+                <H1 class=classes!("docs-title")>{"Switch"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html! {

--- a/yewprint-doc/src/tabs/example.rs
+++ b/yewprint-doc/src/tabs/example.rs
@@ -73,8 +73,8 @@ impl Component for Example {
                                 Nasr, and date to between c. 3500 and c. 3000 BCE."}
                             </> },
                             title: html!(<strong>{"Sumer"}</strong>),
-                            panel_class: None,
-                            title_class: None,
+                            panel_class: Classes,
+                            title_class: Classes,
                         },
                         Tab {
                             disabled: false,
@@ -98,16 +98,16 @@ impl Component for Example {
                                 Minoans \"the first link in the European chain\"."}
                             </> },
                             title: html!(<em>{"Minoan"}</em>),
-                            panel_class: None,
-                            title_class: None,
+                            panel_class: Classes,
+                            title_class: Classes,
                         },
                         Tab {
                             disabled: true,
                             id: Civilization::AncientEgypt,
                             panel: html!(),
                             title: html!(<u>{"Ancient Egypt"}</u>),
-                            panel_class: None,
-                            title_class: None,
+                            panel_class: Classes,
+                            title_class: Classes,
                         },
                         Tab {
                             disabled: false,
@@ -130,8 +130,8 @@ impl Component for Example {
                                 Pakistan."}
                             </> },
                             title: html!("Indus Valley"),
-                            panel_class: None,
-                            title_class: None,
+                            panel_class: Classes,
+                            title_class: Classes,
                         },
                     ]
                 />

--- a/yewprint-doc/src/tabs/example.rs
+++ b/yewprint-doc/src/tabs/example.rs
@@ -73,8 +73,8 @@ impl Component for Example {
                                 Nasr, and date to between c. 3500 and c. 3000 BCE."}
                             </> },
                             title: html!(<strong>{"Sumer"}</strong>),
-                            panel_class: Classes,
-                            title_class: Classes,
+                            panel_class: Classes::default(),
+                            title_class: Classes::default(),
                         },
                         Tab {
                             disabled: false,
@@ -98,16 +98,16 @@ impl Component for Example {
                                 Minoans \"the first link in the European chain\"."}
                             </> },
                             title: html!(<em>{"Minoan"}</em>),
-                            panel_class: Classes,
-                            title_class: Classes,
+                            panel_class: Classes::default(),
+                            title_class: Classes::default(),
                         },
                         Tab {
                             disabled: true,
                             id: Civilization::AncientEgypt,
                             panel: html!(),
                             title: html!(<u>{"Ancient Egypt"}</u>),
-                            panel_class: Classes,
-                            title_class: Classes,
+                            panel_class: Classes::default(),
+                            title_class: Classes::default(),
                         },
                         Tab {
                             disabled: false,
@@ -130,8 +130,8 @@ impl Component for Example {
                                 Pakistan."}
                             </> },
                             title: html!("Indus Valley"),
-                            panel_class: Classes,
-                            title_class: Classes,
+                            panel_class: Classes::default(),
+                            title_class: Classes::default(),
                         },
                     ]
                 />

--- a/yewprint-doc/src/tabs/mod.rs
+++ b/yewprint-doc/src/tabs/mod.rs
@@ -42,7 +42,7 @@ impl Component for TabsDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Tabs"}</H1>
+                <H1 class=classes!("docs-title")>{"Tabs"}</H1>
                 <div>
                     <ExampleContainer
                         source=source

--- a/yewprint-doc/src/tag/mod.rs
+++ b/yewprint-doc/src/tag/mod.rs
@@ -67,7 +67,7 @@ impl Component for TagDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Tag"}</H1>
+                <H1 class=classes!("docs-title")>{"Tag"}</H1>
                 <ExampleContainer
                     source=source
                     props=Some(html!{

--- a/yewprint-doc/src/text/mod.rs
+++ b/yewprint-doc/src/text/mod.rs
@@ -42,7 +42,7 @@ impl Component for TextDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Text"}</H1>
+                <H1 class=classes!("docs-title")>{"Text"}</H1>
                 <div>
                     <ExampleContainer
                         source=source

--- a/yewprint-doc/src/tree/mod.rs
+++ b/yewprint-doc/src/tree/mod.rs
@@ -31,7 +31,7 @@ impl Component for TreeDoc {
 
         html! {
             <div>
-                <H1 class="docs-title">{"Tree"}</H1>
+                <H1 class=classes!("docs-title")>{"Tree"}</H1>
                 <ExampleContainer source=source>
                     <Example />
                 </ExampleContainer>

--- a/yewprint/Cargo.toml
+++ b/yewprint/Cargo.toml
@@ -16,10 +16,10 @@ is-it-maintained-issue-resolution = { repository = "cecton/yewprint" }
 is-it-maintained-open-issues = { repository = "cecton/yewprint" }
 
 [dependencies]
-yew = { git = "https://github.com/yewstack/yew.git", rev = "1507c21b" }
+yew = { git = "https://github.com/yewstack/yew.git", rev = "db3170f629f" }
 web-sys = "0.3"
 id_tree = { version = "1.7", optional = true }
-yewtil = { git = "https://github.com/yewstack/yew.git", rev = "1507c21b", features = ["pure"] }
+yewtil = { git = "https://github.com/yewstack/yew.git", rev = "db3170f629f", features = ["pure"] }
 # NOTE: this dependency needs to be removed when the feature bool_to_option lands in stable
 #       https://github.com/rust-lang/rust/issues/64260
 boolinator = "2.4.0"

--- a/yewprint/src/button_group.rs
+++ b/yewprint/src/button_group.rs
@@ -45,7 +45,7 @@ impl Component for ButtonGroup {
     fn view(&self) -> Html {
         html! {
             <div
-                class=(
+                class=classes!(
                     "bp3-button-group",
                     self.props.minimal.as_some("bp3-minimal"),
                     self.props.fill.as_some("bp3-fill"),

--- a/yewprint/src/buttons.rs
+++ b/yewprint/src/buttons.rs
@@ -23,7 +23,7 @@ pub struct Props {
     #[prop_or_default]
     pub onclick: Callback<MouseEvent>,
     #[prop_or_default]
-    pub class: String,
+    pub class: Classes,
     #[prop_or_default]
     pub children: html::Children,
 }

--- a/yewprint/src/buttons.rs
+++ b/yewprint/src/buttons.rs
@@ -52,7 +52,7 @@ impl Component for Button {
     fn view(&self) -> Html {
         html! {
             <button
-                class=(
+                class=classes!(
                     "bp3-button",
                     self.props.fill.as_some("bp3-fill"),
                     self.props.minimal.as_some("bp3-minimal"),

--- a/yewprint/src/callout.rs
+++ b/yewprint/src/callout.rs
@@ -9,7 +9,7 @@ pub struct Callout {
 #[derive(Clone, PartialEq, Properties)]
 pub struct Props {
     #[prop_or_default]
-    pub class: String,
+    pub class: Classes,
     #[prop_or(false)]
     pub without_icon: bool,
     #[prop_or_default]

--- a/yewprint/src/card/mod.rs
+++ b/yewprint/src/card/mod.rs
@@ -40,15 +40,14 @@ impl Component for Card {
     }
 
     fn view(&self) -> Html {
-        let mut classes = Classes::from("bp3-card")
-            .extend(&self.props.class)
-            .extend(self.props.elevation);
-        if self.props.interactive {
-            classes.push("bp3-interactive");
-        }
-
         html! {
-            <div class=classes onclick={self.props.onclick.clone()}>
+            <div class=classes!(
+                "bp3-card",
+                &self.props.class,
+                self.props.elevation,
+                Some("bp3-interactive"),
+            )
+            onclick={self.props.onclick.clone()}>
                 {self.props.children.clone()}
             </div>
         }

--- a/yewprint/src/collapse.rs
+++ b/yewprint/src/collapse.rs
@@ -177,9 +177,9 @@ impl Component for Collapse {
         }
 
         html! {
-            <div class="bp3-collapse" style={container_style}>
+            <div class=classes!("bp3-collapse") style={container_style}>
                 <div
-                    class="bp3-collapse-body"
+                    class=classes!("bp3-collapse-body")
                     style={content_style}
                     aria-hidden={!self.render_children}
                     ref={self.contents_ref.clone()}

--- a/yewprint/src/control_group.rs
+++ b/yewprint/src/control_group.rs
@@ -39,7 +39,7 @@ impl Component for ControlGroup {
     fn view(&self) -> Html {
         html! {
             <div
-                class=(
+                class=classes!(
                     "bp3-control-group",
                     self.props.fill.as_some("bp3-fill"),
                     self.props.vertical.as_some("bp3-vertical"),

--- a/yewprint/src/divider.rs
+++ b/yewprint/src/divider.rs
@@ -37,7 +37,7 @@ impl Component for Divider {
     fn view(&self) -> Html {
         html! {
             <span
-                class=(
+                class=classes!(
                     "bp3-divider",
                     self.props.vertical.as_some("bp3-vertical"),
                 )

--- a/yewprint/src/html_elements.rs
+++ b/yewprint/src/html_elements.rs
@@ -16,7 +16,7 @@ macro_rules! build_component {
         impl PureComponent for $props_name {
             fn render(&self) -> Html {
                 html! {
-                    <$tag class=($class, self.class.clone())>
+                    <$tag class=classes!($class, self.class.clone())>
                         {self.children.clone()}
                     </$tag>
                 }

--- a/yewprint/src/html_elements.rs
+++ b/yewprint/src/html_elements.rs
@@ -8,7 +8,7 @@ macro_rules! build_component {
         #[derive(Debug, Clone, PartialEq, Properties)]
         pub struct $props_name {
             #[prop_or_default]
-            pub class: String,
+            pub class: Classes,
             #[prop_or_default]
             pub children: html::Children,
         }

--- a/yewprint/src/html_select.rs
+++ b/yewprint/src/html_select.rs
@@ -89,7 +89,7 @@ impl<T: Clone + PartialEq + Hash + 'static> Component for HtmlSelect<T> {
 
         html! {
             <div
-                class=(
+                class=classes!(
                     "bp3-html-select",
                     self.props.minimal.as_some("bp3-minimal"),
                     self.props.large.as_some("bp3-large"),

--- a/yewprint/src/icon.rs
+++ b/yewprint/src/icon.rs
@@ -20,7 +20,7 @@ pub struct Icon {
 pub struct IconProps {
     pub icon: IconName,
     #[prop_or_default]
-    pub class: String,
+    pub class: Classes,
     #[prop_or_default]
     pub title: Option<String>,
     #[prop_or_default]

--- a/yewprint/src/icon.rs
+++ b/yewprint/src/icon.rs
@@ -69,7 +69,7 @@ impl Component for Icon {
 
         html! {
             <span
-                class=("bp3-icon", self.props.class.clone(), self.props.intent)
+                class=classes!("bp3-icon", self.props.class.clone(), self.props.intent)
                 onclick=self.props.onclick.clone()
             >
                 <svg

--- a/yewprint/src/input_group.rs
+++ b/yewprint/src/input_group.rs
@@ -52,7 +52,7 @@ impl Component for InputGroup {
     fn view(&self) -> Html {
         html! {
             <div
-                class=(
+                class=classes!(
                     "bp3-input-group",
                     self.props.disabled.as_some("bp3-disabled"),
                     self.props.fill.as_some("bp3-fill"),

--- a/yewprint/src/lib.rs
+++ b/yewprint/src/lib.rs
@@ -40,7 +40,7 @@ pub use text::*;
 #[cfg(feature = "tree")]
 pub use tree::*;
 
-use yew::virtual_dom::Classes;
+use yew::Classes;
 
 #[macro_export]
 macro_rules! if_html {

--- a/yewprint/src/menu.rs
+++ b/yewprint/src/menu.rs
@@ -63,7 +63,7 @@ pub struct MenuItemProps {
     #[prop_or_default]
     pub text: yew::virtual_dom::VNode,
     #[prop_or_default]
-    pub text_class: Option<String>,
+    pub text_class: Classes,
     #[prop_or_default]
     pub active: bool,
     #[prop_or_default]
@@ -75,7 +75,7 @@ pub struct MenuItemProps {
     #[prop_or_default]
     pub label: Option<yew::virtual_dom::VNode>,
     #[prop_or_default]
-    pub label_class: Option<String>,
+    pub label_class: Classes,
     // TODO: pub multiline: bool, (requires <Text>)
     // TODO: popover_props, should_dismiss_popover
     #[prop_or_default]
@@ -185,14 +185,14 @@ impl Component for MenuDivider {
             if let Some(title) = self.props.title.clone() {
                 html! {
                     <li
-                        class="bp3-menu-header"
+                        class=classes!("bp3-menu-header")
                     >
                         <H6>{title}</H6>
                     </li>
                 }
             } else {
                 html! {
-                    <li class="bp3-menu-divider" />
+                    <li class=classes!("bp3-menu-divider") />
                 }
             }
         }

--- a/yewprint/src/menu.rs
+++ b/yewprint/src/menu.rs
@@ -41,7 +41,7 @@ impl Component for Menu {
     fn view(&self) -> Html {
         html! {
             <ul
-                class=(
+                class=classes!(
                     "bp3-menu",
                     self.props.large.as_some("bp3-large"),
                     self.props.class.clone(),
@@ -112,7 +112,7 @@ impl Component for MenuItem {
         html! {
             <li>
                 <a
-                    class=(
+                    class=classes!(
                         "bp3-menu-item",
                         self.props.active.as_some("bp3-active"),
                         self.props.disabled.as_some("bp3-disabled"),
@@ -125,14 +125,14 @@ impl Component for MenuItem {
                     onclick={self.props.onclick.clone()}
                 >
                     <Icon icon={self.props.icon} />
-                    <div class=("bp3-text", "bp3-fill", self.props.text_class.clone())>
+                    <div class=classes!("bp3-text", "bp3-fill", self.props.text_class.clone())>
                         {self.props.text.clone()}
                     </div>
                     {
                         if let Some(label) = self.props.label.clone() {
                             html! {
                                 <span
-                                    class=(
+                                    class=classes!(
                                         "bp3-menu-item-label",
                                         self.props.label_class.clone())
                                 >

--- a/yewprint/src/menu.rs
+++ b/yewprint/src/menu.rs
@@ -11,7 +11,7 @@ pub struct MenuProps {
     #[prop_or_default]
     pub large: bool,
     #[prop_or_default]
-    pub class: Option<String>,
+    pub class: Classes,
     #[prop_or_default]
     pub r#ref: NodeRef,
     pub children: html::Children,
@@ -67,7 +67,7 @@ pub struct MenuItemProps {
     #[prop_or_default]
     pub active: bool,
     #[prop_or_default]
-    pub class: Option<String>,
+    pub class: Classes,
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]

--- a/yewprint/src/progressbar.rs
+++ b/yewprint/src/progressbar.rs
@@ -50,7 +50,7 @@ impl Component for ProgressBar {
         };
         html! {
             <div
-                class=(
+                class=classes!(
                     "bp3-progress-bar",
                     self.props.intent,
                     (!self.props.animate).as_some("bp3-no-animation"),

--- a/yewprint/src/progressbar.rs
+++ b/yewprint/src/progressbar.rs
@@ -57,7 +57,7 @@ impl Component for ProgressBar {
                     (!self.props.stripes).as_some("bp3-no-stripes")
                 )
             >
-                <div class="bp3-progress-meter" style={{width}}/>
+                <div class=classes!("bp3-progress-meter") style={{width}}/>
             </div>
         }
     }

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -45,8 +45,9 @@ impl Component for Switch {
     fn view(&self) -> Html {
         html! {
             <label
-                class=(
-                    "bp3-control bp3-switch",
+                class=classes!(
+                    "bp3-control", 
+                    "bp3-switch",
                     self.props.disabled.as_some("bp3-disabled"),
                     self.props.inline.as_some("bp3-inline"),
                     self.props.large.as_some("bp3-large"),

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -46,7 +46,7 @@ impl Component for Switch {
         html! {
             <label
                 class=classes!(
-                    "bp3-control", 
+                    "bp3-control",
                     "bp3-switch",
                     self.props.disabled.as_some("bp3-disabled"),
                     self.props.inline.as_some("bp3-inline"),

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -60,7 +60,7 @@ impl Component for Switch {
                 disabled=self.props.disabled
             />
             <span
-                class="bp3-control-indicator"
+                class=classes!("bp3-control-indicator")
             >
             </span>
             {self.props.label.clone()}

--- a/yewprint/src/tabs.rs
+++ b/yewprint/src/tabs.rs
@@ -91,14 +91,14 @@ impl<T: Clone + PartialEq + Hash + 'static> Component for Tabs<T> {
 
         html! {
             <div
-                class=(
+                class=classes!(
                     "bp3-tabs",
                     self.props.vertical.as_some("bp3-vertical"),
                     self.props.class.clone(),
                 )
             >
                 <div
-                    class=(
+                    class=classes!(
                         "bp3-tab-list",
                         self.props.large.as_some("bp3-large"),
                     )
@@ -137,7 +137,7 @@ impl<T: Clone + PartialEq + Hash + 'static> Component for Tabs<T> {
                             .iter()
                             .map(|(props, id, title_id, panel_id, selected)| html! {
                                 <div
-                                    class=(
+                                    class=classes!(
                                         "bp3-tab",
                                         props.title_class.clone(),
                                     )
@@ -183,7 +183,7 @@ impl<T: Clone + PartialEq + Hash + 'static> Component for Tabs<T> {
                         })
                         .map(|(props, id, title_id, panel_id, selected)| html! {
                             <div
-                                class=(
+                                class=classes!(
                                     "bp3-tab-panel",
                                     props.panel_class.clone(),
                                 )

--- a/yewprint/src/tabs.rs
+++ b/yewprint/src/tabs.rs
@@ -27,7 +27,7 @@ pub struct TabsProps<T: Clone + PartialEq> {
     #[prop_or_default]
     pub onchange: Callback<T>,
     #[prop_or_default]
-    pub class: String,
+    pub class: Classes,
     pub tabs: Vec<Tab<T>>,
 }
 

--- a/yewprint/src/tabs.rs
+++ b/yewprint/src/tabs.rs
@@ -209,6 +209,6 @@ pub struct Tab<T> {
     pub id: T,
     pub title: Html,
     pub panel: Html,
-    pub title_class: Option<String>,
-    pub panel_class: Option<String>,
+    pub title_class: Classes,
+    pub panel_class: Classes,
 }

--- a/yewprint/src/tag.rs
+++ b/yewprint/src/tag.rs
@@ -95,7 +95,7 @@ impl Component for Tag {
             >
                 {icon}
                 <Text
-                    class="bp3-fill"
+                    class=classes!("bp3-fill")
                     ellipsize={!self.props.multiline}
                     title=self.props.title.clone()
                     inline=true

--- a/yewprint/src/tag.rs
+++ b/yewprint/src/tag.rs
@@ -81,7 +81,7 @@ impl Component for Tag {
 
         html! {
             <span
-                class=(
+                class=classes!(
                     "bp3-tag",
                     self.props.intent,
                     self.props.active.as_some("bp3-active"),

--- a/yewprint/src/tag.rs
+++ b/yewprint/src/tag.rs
@@ -70,7 +70,7 @@ impl Component for Tag {
             let Some(callback) = self.props.onremove.clone() =>
             html!(
                 <button
-                    class="bp3-tag-remove"
+                    class=classes!("bp3-tag-remove")
                     onclick={callback}
                     tabindex?={self.props.interactive.as_some(0)}
                 >

--- a/yewprint/src/text.rs
+++ b/yewprint/src/text.rs
@@ -12,7 +12,7 @@ pub struct Props {
     #[prop_or_default]
     pub children: Children,
     #[prop_or_default]
-    pub class: String,
+    pub class: Classes,
     /// Wrap text in `span` instead of `div`.
     #[prop_or_default]
     pub inline: bool,

--- a/yewprint/src/text.rs
+++ b/yewprint/src/text.rs
@@ -44,7 +44,7 @@ impl Component for Text {
     fn view(&self) -> Html {
         html! {
             <@{if self.props.inline { "span" } else { "div"}}
-                class=(
+                class=classes!(
                     self.props.class.clone(),
                     self.props.ellipsize.as_some("bp3-text-overflow-ellipsis"),
                 )

--- a/yewprint/src/tree.rs
+++ b/yewprint/src/tree.rs
@@ -310,7 +310,10 @@ impl Component for TreeNode {
         let content_style = format!("padding-left: {}px;", 23 * self.props.depth);
 
         html! {
-            <li class=classes!("bp3-tree-node", self.props.is_selected.as_some("bp3-tree-node-selected"))>
+            <li class=classes!(
+                "bp3-tree-node",
+                self.props.is_selected.as_some("bp3-tree-node-selected")
+            )>
                 <div
                     class="bp3-tree-node-content"
                     style=content_style

--- a/yewprint/src/tree.rs
+++ b/yewprint/src/tree.rs
@@ -339,8 +339,8 @@ impl Component for TreeNode {
                         }
                     }
                     <Icon
-                        class="bp3-tree-node-icon"
-                        icon=self.props.icon.unwrap_or_default()
+                        class=classes!("bp3-tree-node-icon"),
+                        icon=self.props.icon.unwrap_or_default(),
                         color=self.props.icon_color.clone(),
                         intent=self.props.icon_intent,
                     />

--- a/yewprint/src/tree.rs
+++ b/yewprint/src/tree.rs
@@ -350,7 +350,11 @@ impl Component for TreeNode {
                     <span class=classes!("bp3-tree-node-label")>{self.props.label.clone()}</span>
                     {
                         if let Some(label) = self.props.secondary_label.clone() {
-                            html!(<span class=classes!("bp3-tree-node-secondary-label")>{label}</span>)
+                            html!(
+                                <span class=classes!("bp3-tree-node-secondary-label")>
+                                    {label}
+                                </span>
+                            )
                         } else {
                             html!()
                         }

--- a/yewprint/src/tree.rs
+++ b/yewprint/src/tree.rs
@@ -141,8 +141,8 @@ impl<T: Clone + PartialEq + 'static> Component for Tree<T> {
         };
 
         html! {
-            <div class="bp3-tree">
-                <ul class="bp3-tree-node-list">
+            <div class=classes!("bp3-tree")>
+                <ul class=classes!("bp3-tree-node-list")>
                     {nodes}
                 </ul>
             </div>
@@ -347,17 +347,17 @@ impl Component for TreeNode {
                         color=self.props.icon_color.clone()
                         intent=self.props.icon_intent
                     />
-                    <span class="bp3-tree-node-label">{self.props.label.clone()}</span>
+                    <span class=classes!("bp3-tree-node-label")>{self.props.label.clone()}</span>
                     {
                         if let Some(label) = self.props.secondary_label.clone() {
-                            html!(<span class="bp3-tree-node-secondary-label">{label}</span>)
+                            html!(<span class=classes!("bp3-tree-node-secondary-label")>{label}</span>)
                         } else {
                             html!()
                         }
                     }
                 </div>
                 <Collapse is_open=self.props.is_expanded>
-                    <ul class="bp3-tree-node-list">
+                    <ul class=classes!("bp3-tree-node-list")>
                         {self.props.children.clone()}
                     </ul>
                 </Collapse>

--- a/yewprint/src/tree.rs
+++ b/yewprint/src/tree.rs
@@ -330,7 +330,7 @@ impl Component for TreeNode {
 
                             html! {
                                 <Icon
-                                    class=class.to_string()
+                                    class=classes!(class.to_string())
                                     icon=IconName::ChevronRight
                                     onclick=self.handler_caret_click.clone()
                                 />
@@ -342,7 +342,7 @@ impl Component for TreeNode {
                         }
                     }
                     <Icon
-                        class="bp3-tree-node-icon"
+                        class=classes!("bp3-tree-node-icon")
                         icon=self.props.icon.unwrap_or_default()
                         color=self.props.icon_color.clone()
                         intent=self.props.icon_intent

--- a/yewprint/src/tree.rs
+++ b/yewprint/src/tree.rs
@@ -310,7 +310,7 @@ impl Component for TreeNode {
         let content_style = format!("padding-left: {}px;", 23 * self.props.depth);
 
         html! {
-            <li class=("bp3-tree-node", self.props.is_selected.as_some("bp3-tree-node-selected"))>
+            <li class=classes!("bp3-tree-node", self.props.is_selected.as_some("bp3-tree-node-selected"))>
                 <div
                     class="bp3-tree-node-content"
                     style=content_style
@@ -339,10 +339,10 @@ impl Component for TreeNode {
                         }
                     }
                     <Icon
-                        class=classes!("bp3-tree-node-icon"),
-                        icon=self.props.icon.unwrap_or_default(),
-                        color=self.props.icon_color.clone(),
-                        intent=self.props.icon_intent,
+                        class="bp3-tree-node-icon"
+                        icon=self.props.icon.unwrap_or_default()
+                        color=self.props.icon_color.clone()
+                        intent=self.props.icon_intent
                     />
                     <span class="bp3-tree-node-label">{self.props.label.clone()}</span>
                     {


### PR DESCRIPTION
We need to do this because of this issue and yewtil:

https://github.com/yewstack/yew/issues/1681

Also related: https://github.com/dtolnay/syn/issues/956