### PR TITLE
Add link the the actual page in the example's MenuItem

### DIFF
--- a/yewprint-doc/src/menu/example.rs
+++ b/yewprint-doc/src/menu/example.rs
@@ -1,14 +1,21 @@
+use crate::app::DocMenu;
 use yew::prelude::*;
 use yewprint::{Icon, IconName, Menu, MenuDivider, MenuItem};
 
-pub struct Example {}
+pub struct Example {
+    link: ComponentLink<Self>,
+}
+
+pub enum Msg {
+    GoToMenu(DocMenu),
+}
 
 impl Component for Example {
-    type Message = ();
+    type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, _link: ComponentLink<Self>) -> Self {
-        Self {}
+    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+        Self { link }
     }
 
     fn update(&mut self, _msg: Self::Message) -> ShouldRender {
@@ -31,14 +38,23 @@ impl Component for Example {
                     <MenuItem
                         icon=IconName::NewTextBox
                         text={html!{"New text box"}}
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                     <MenuItem
                         icon=IconName::NewObject
                         text={html!{"New object"}}
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                     <MenuItem
                         icon=IconName::NewLink
                         text={html!{"New link"}}
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                     <MenuDivider />
                     <MenuItem
@@ -47,6 +63,9 @@ impl Component for Example {
                         label=html! {
                             <Icon icon=IconName::Share />
                         }
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                 </Menu>
                 <Menu>
@@ -55,11 +74,17 @@ impl Component for Example {
                         icon=IconName::Cut
                         text={html!("Cut")}
                         label={html!("Ctrl+X")}
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                     <MenuItem
                         icon=IconName::Duplicate
                         text={html!("Copy")}
                         label={html!("Ctrl+C")}
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                     <MenuItem
                         icon=IconName::Clipboard
@@ -71,16 +96,23 @@ impl Component for Example {
                     <MenuItem
                         icon=IconName::AlignLeft
                         text={html!("Alignment")}
-                        disabled=false
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                     <MenuItem
                         icon=IconName::Style
                         text={html!("Style")}
-
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                     <MenuItem
                         icon=IconName::Asterisk
                         text={html!("Miscellaneous")}
+                        href="#menu"
+                        onclick=self.link
+                            .callback(|_| Msg::GoToMenu(DocMenu::Menu))
                     />
                 </Menu>
             </>


### PR DESCRIPTION
I have seen that when you click on a MenuItem in the example of the Menu component, you go to the main page.
So I have add some links to improve the code example and now when you click on a link in the example, you stay on the Menu component page.